### PR TITLE
.*: Use <limits> instead of <climits>

### DIFF
--- a/phtree/common/base_types.h
+++ b/phtree/common/base_types.h
@@ -20,8 +20,8 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <climits>
 #include <cstdint>
+#include <limits>
 #include <sstream>
 
 /*

--- a/phtree/common/common.h
+++ b/phtree/common/common.h
@@ -26,9 +26,9 @@
 #include "flat_sparse_map.h"
 #include "tree_stats.h"
 #include <cassert>
-#include <climits>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <sstream>
 
 namespace improbable::phtree {

--- a/phtree/common/distance.h
+++ b/phtree/common/distance.h
@@ -24,9 +24,9 @@
 #include "flat_sparse_map.h"
 #include "tree_stats.h"
 #include <cassert>
-#include <climits>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <sstream>
 
 namespace improbable::phtree {

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -24,9 +24,9 @@
 #include "flat_sparse_map.h"
 #include "tree_stats.h"
 #include <cassert>
-#include <climits>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <sstream>
 
 namespace improbable::phtree {


### PR DESCRIPTION
## Changes
Replaced `include <climits>` with `include<limits>` in all files. It was necessary to replace it in `phtree/common/base_types.h` to get the project to build on Linux with either GCC 11 or Clang 13. Other files were changed for consistency.

Compile error without the change: [compile-error.log](https://github.com/improbable-eng/phtree-cpp/files/7817781/compile-error.log)

## Verification
Only built in on my machine.