### PR TITLE
filter: Add FilterSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ There are numerous ways to improve performance. The following list gives an over
 4) **Use non-box query shapes**. Depending on the use case it may be more suitable to use a custom filter for querier. 
 For example: 
 
-    `tree.for_each(callback, MySphereFIlter(center, radius, tree.converter()));` 
+    `tree.for_each(callback, FilterSphere(center, radius, ScalarConverterIEEE));`
 
 5) **Use a different data converter**. The default converter of the PH-Tree results in a reasonably fast index. 
 Its biggest advantage is that it provides lossless conversion from floating point coordinates to PH-Tree coordinates 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ There are numerous ways to improve performance. The following list gives an over
 4) **Use non-box query shapes**. Depending on the use case it may be more suitable to use a custom filter for querier. 
 For example: 
 
-    `tree.for_each(callback, FilterSphere(center, radius, ScalarConverterIEEE));`
+    `tree.for_each(callback, FilterSphere(center, radius, tree.converter()));`
 
 5) **Use a different data converter**. The default converter of the PH-Tree results in a reasonably fast index. 
 Its biggest advantage is that it provides lossless conversion from floating point coordinates to PH-Tree coordinates 

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -23,6 +23,7 @@
 #include "flat_array_map.h"
 #include "flat_sparse_map.h"
 #include "tree_stats.h"
+#include <algorithm>
 #include <cassert>
 #include <climits>
 #include <cmath>
@@ -198,16 +199,11 @@ class FilterSphere {
         KeyInternal closest_in_bounds;
         for (size_t i = 0; i < prefix.size(); ++i) {
             // calculate lower and upper bound for dimension for given node
-            ScalarInternal lower_bound = prefix[i] & node_min_bits;
-            ScalarInternal upper_bound = prefix[i] | node_max_bits;
+            ScalarInternal lo = prefix[i] & node_min_bits;
+            ScalarInternal hi = prefix[i] | node_max_bits;
 
             // choose value closest to center for dimension
-            closest_in_bounds[i] = center_internal_[i];
-            if (closest_in_bounds[i] < lower_bound) {
-                closest_in_bounds[i] = lower_bound;
-            } else if (closest_in_bounds[i] > upper_bound) {
-                closest_in_bounds[i] = upper_bound;
-            }
+            closest_in_bounds[i] = std::clamp(center_internal_[i], lo, hi);
         }
 
         KeyExternal closest_point = converter_.post(closest_in_bounds);

--- a/phtree/common/filter_test.cc
+++ b/phtree/common/filter_test.cc
@@ -20,17 +20,6 @@
 
 using namespace improbable::phtree;
 
-class ConverterNoOpScalar {
-  public:
-    static scalar_64_t pre(double value) {
-        return value;
-    }
-
-    static double post(scalar_64_t value) {
-        return value;
-    }
-};
-
 TEST(PhTreeFilterTest, FilterSphereTest) {
     FilterSphere<ConverterNoOp<2, scalar_64_t>, DistanceEuclidean<2>> filter{{5, 3}, 5};
     // root is always valid

--- a/phtree/common/filter_test.cc
+++ b/phtree/common/filter_test.cc
@@ -20,6 +20,41 @@
 
 using namespace improbable::phtree;
 
+class ConverterNoOpScalar {
+  public:
+    static scalar_64_t pre(double value) {
+        return value;
+    }
+
+    static double post(scalar_64_t value) {
+        return value;
+    }
+};
+
+TEST(PhTreeFilterTest, FilterSphereTest) {
+    FilterSphere<2, scalar_64_t, scalar_64_t, ConverterNoOpScalar> filter{{5, 3}, 5};
+    // root is always valid
+    ASSERT_TRUE(filter.IsNodeValid({0, 0}, 63));
+    // valid because node encompasses the circle
+    ASSERT_TRUE(filter.IsNodeValid({1, 1}, 10));
+    // valid because circle encompasses the node
+    ASSERT_TRUE(filter.IsNodeValid({5, 5}, 2));
+    // valid because circle encompasses the node AABB
+    ASSERT_TRUE(filter.IsNodeValid({7, 7}, 1));
+    // valid because circle touches the edge of the node AABB
+    ASSERT_TRUE(filter.IsNodeValid({5, 9}, 1));
+    // valid because circle cuts edge of node AABB
+    ASSERT_TRUE(filter.IsNodeValid({12, 7}, 3));
+    ASSERT_TRUE(filter.IsNodeValid({10, 7}, 2));
+    // invalid because node is just outside the circle
+    ASSERT_FALSE(filter.IsNodeValid({5, 10}, 1));
+    ASSERT_FALSE(filter.IsNodeValid({12, 12}, 3));
+
+    ASSERT_TRUE(filter.IsEntryValid({3, 7}, nullptr));
+    ASSERT_TRUE(filter.IsEntryValid({5, 8}, nullptr));
+    ASSERT_FALSE(filter.IsEntryValid({3, 8}, nullptr));
+}
+
 TEST(PhTreeFilterTest, BoxFilterTest) {
     FilterAABB<ConverterNoOp<2, scalar_64_t>> filter{{3, 3}, {7, 7}};
     // root is always valid

--- a/phtree/common/filter_test.cc
+++ b/phtree/common/filter_test.cc
@@ -32,7 +32,7 @@ class ConverterNoOpScalar {
 };
 
 TEST(PhTreeFilterTest, FilterSphereTest) {
-    FilterSphere<2, scalar_64_t, scalar_64_t, ConverterNoOpScalar> filter{{5, 3}, 5};
+    FilterSphere<ConverterNoOp<2, scalar_64_t>, DistanceEuclidean<2>> filter{{5, 3}, 5};
     // root is always valid
     ASSERT_TRUE(filter.IsNodeValid({0, 0}, 63));
     // valid because node encompasses the circle


### PR DESCRIPTION
## Changes
Add the `FilterSphere` filter than can filter points for a sphere given a center and a radius.

Unfortunately I had to use a scalar converter that needs to be hand-picked and match the multidimensional converter used in the tree. Please let me know how it can be improved.

## Verification
Added a test case.