### PR TITLE
Fixed numerous warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,6 +29,10 @@ build:ci --announce_rc
 build:linux --copt="-fvisibility=hidden"
 build:linux --copt="-fno-omit-frame-pointer"  # for friendlier stack traces
 build:linux --copt="-Wno-error"
+build:linux --copt="-Wall"
+build:linux --copt="-Wextra"
+build:linux --copt="-Werror=return-type"
+build:linux --copt="-Werror=switch"
 build:linux --copt="-mavx"
 build:linux --copt="-Wsequence-point"
 build:linux --copt="-Wsign-compare"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nothing yet.
+### Added
+- FilterSphere for filtering by sphere constraint (by ctbur)
+### Changed
+- Fixed imports  `<climits>` -> `<limits>` (by ctbur)
+- Fix "unused" warnings
 
 ## [1.0.1] - 2021-05-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - FilterSphere for filtering by sphere constraint (by ctbur)
 ### Changed
 - Fixed imports  `<climits>` -> `<limits>` (by ctbur)
-- Fix "unused" warnings
+- Fixed warnings:
+  - "unused" function argument warnings
+  - gcc/clang warnings
+  - MSVC warnings
+  - reserved identifier warnings (identifiers starting with `_`)
 
 ## [1.0.1] - 2021-05-06
 ### Changed

--- a/phtree/benchmark/count_mm_d_benchmark.cc
+++ b/phtree/benchmark/count_mm_d_benchmark.cc
@@ -118,7 +118,7 @@ void InsertEntry(
 }
 
 struct CounterTreeWithMap {
-    void operator()(const PhPointD<3>& key, const BucketType& value) {
+    void operator()(const PhPointD<3>&, const BucketType& value) {
         for (auto& x : value) {
             n_ += x.size();
         }

--- a/phtree/benchmark/count_mm_d_benchmark.cc
+++ b/phtree/benchmark/count_mm_d_benchmark.cc
@@ -79,7 +79,7 @@ class IndexBenchmark {
 
 template <dimension_t DIM, Scenario SCENARIO>
 IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(benchmark::State& state, double avg_query_result_size)
-: data_type_{static_cast<const TestGenerator>(state.range(1))}
+: data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
 , avg_query_result_size_(avg_query_result_size)
 , tree_{}

--- a/phtree/benchmark/erase_benchmark.cc
+++ b/phtree/benchmark/erase_benchmark.cc
@@ -91,7 +91,7 @@ void IndexBenchmark<DIM>::SetupWorld(benchmark::State& state) {
 }
 
 template <dimension_t DIM>
-void IndexBenchmark<DIM>::Insert(benchmark::State& state, PhTree<DIM, int>& tree) {
+void IndexBenchmark<DIM>::Insert(benchmark::State&, PhTree<DIM, int>& tree) {
     for (int i = 0; i < num_entities_; ++i) {
         tree.emplace(points_[i], i);
     }

--- a/phtree/benchmark/erase_d_benchmark.cc
+++ b/phtree/benchmark/erase_d_benchmark.cc
@@ -91,7 +91,7 @@ void IndexBenchmark<DIM>::SetupWorld(benchmark::State& state) {
 }
 
 template <dimension_t DIM>
-void IndexBenchmark<DIM>::Insert(benchmark::State& state, PhTreeD<DIM, int>& tree) {
+void IndexBenchmark<DIM>::Insert(benchmark::State&, PhTreeD<DIM, int>& tree) {
     for (int i = 0; i < num_entities_; ++i) {
         tree.emplace(points_[i], i);
     }

--- a/phtree/benchmark/extent_benchmark_weird.cc
+++ b/phtree/benchmark/extent_benchmark_weird.cc
@@ -104,7 +104,7 @@ class FilterBoxIntersection {
         max_include_bits = PRE(maxExclude);
     }
 
-    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>& key, const int& value) const {
+    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>& key, const int&) const {
         for (int i = 0; i < DIM; ++i) {
             if (key[i] < min_include_bits[i] || key[i] > max_include_bits[i]) {
                 return false;
@@ -146,11 +146,11 @@ class FilterTrue {
         maxIncludeBits = PRE(maxExclude);
     }
 
-    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>& key, const int& value) const {
+    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>&, const int&) const {
         return true;
     }
 
-    [[nodiscard]] bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 
@@ -164,11 +164,11 @@ class FilterTrue2 {
   public:
     FilterTrue2() : minIncludeBits{}, maxIncludeBits{} {};
 
-    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>& key, const int& value) const {
+    [[nodiscard]] bool IsEntryValid(const PhPoint<DIM>&, const int&) const {
         return true;
     }
 
-    [[nodiscard]] bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 
@@ -179,11 +179,11 @@ class FilterTrue2 {
 
 template <dimension_t DIM, typename T>
 struct FilterTrue3 {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T&) const {
         return true;
     }
 
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };

--- a/phtree/benchmark/find_benchmark.cc
+++ b/phtree/benchmark/find_benchmark.cc
@@ -115,7 +115,7 @@ void IndexBenchmark<DIM>::SetupWorld(benchmark::State& state) {
 }
 
 template <dimension_t DIM>
-int IndexBenchmark<DIM>::QueryWorldCount(benchmark::State& state) {
+int IndexBenchmark<DIM>::QueryWorldCount(benchmark::State&) {
     static int pos = 0;
     pos = (pos + 1) % num_entities_;
     bool found = true;
@@ -130,7 +130,7 @@ int IndexBenchmark<DIM>::QueryWorldCount(benchmark::State& state) {
 }
 
 template <dimension_t DIM>
-int IndexBenchmark<DIM>::QueryWorldFind(benchmark::State& state) {
+int IndexBenchmark<DIM>::QueryWorldFind(benchmark::State&) {
     static int pos = 0;
     pos = (pos + 1) % num_entities_;
     bool found = true;

--- a/phtree/benchmark/query_box_d_benchmark.cc
+++ b/phtree/benchmark/query_box_d_benchmark.cc
@@ -120,7 +120,7 @@ void IndexBenchmark<DIM, QUERY_TYPE>::SetupWorld(benchmark::State& state) {
 
 template <dimension_t DIM, typename T>
 struct Counter {
-    void operator()(BoxType<DIM> key, T& t) {
+    void operator()(BoxType<DIM>, T&) {
         ++n_;
     }
 

--- a/phtree/benchmark/query_d_benchmark.cc
+++ b/phtree/benchmark/query_d_benchmark.cc
@@ -120,7 +120,7 @@ void IndexBenchmark<DIM, QUERY_TYPE>::SetupWorld(benchmark::State& state) {
 
 template <dimension_t DIM, typename T>
 struct Counter {
-    void operator()(PointType<DIM> key, T& t) {
+    void operator()(PointType<DIM>, T&) {
         ++n_;
     }
 

--- a/phtree/benchmark/query_mm_box_d_benchmark.cc
+++ b/phtree/benchmark/query_mm_box_d_benchmark.cc
@@ -80,7 +80,7 @@ class IndexBenchmark {
 
 template <dimension_t DIM, Scenario SCENARIO>
 IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(benchmark::State& state, double avg_query_result_size)
-: data_type_{static_cast<const TestGenerator>(state.range(1))}
+: data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
 , avg_query_result_size_(avg_query_result_size)
 , tree_{}

--- a/phtree/benchmark/query_mm_box_d_benchmark.cc
+++ b/phtree/benchmark/query_mm_box_d_benchmark.cc
@@ -126,7 +126,7 @@ bool CheckPosition(const payload_t& entity, const QueryBox& query) {
 }
 
 struct CounterTreeWithMap {
-    void operator()(const PhBoxD<3>& key, const BucketType& value) {
+    void operator()(const PhBoxD<3>&, const BucketType& value) {
         for (auto& x : value) {
             n_ += CheckPosition(x, box_);
         }
@@ -136,7 +136,7 @@ struct CounterTreeWithMap {
 };
 
 struct CounterMultiMap {
-    void operator()(const PhBoxD<3>& key, const payload_t& value) {
+    void operator()(const PhBoxD<3>&, const payload_t& value) {
         n_ += CheckPosition(value, box_);
     }
     const QueryBox& box_;

--- a/phtree/benchmark/query_mm_d_benchmark.cc
+++ b/phtree/benchmark/query_mm_d_benchmark.cc
@@ -82,7 +82,7 @@ class IndexBenchmark {
 
 template <dimension_t DIM, Scenario SCENARIO>
 IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(benchmark::State& state, double avg_query_result_size)
-: data_type_{static_cast<const TestGenerator>(state.range(1))}
+: data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
 , avg_query_result_size_(avg_query_result_size)
 , tree_{}

--- a/phtree/benchmark/query_mm_d_benchmark.cc
+++ b/phtree/benchmark/query_mm_d_benchmark.cc
@@ -129,7 +129,7 @@ bool CheckPosition(const payload_t& entity, const TestPoint& center, double radi
 }
 
 struct CounterTreeWithMap {
-    void operator()(const PhPointD<3>& key, const BucketType& value) {
+    void operator()(const PhPointD<3>&, const BucketType& value) {
         for (auto& x : value) {
             // n_ += (x.entity_id_ >= 0);
             n_ += CheckPosition(x, center_, radius_);
@@ -141,7 +141,7 @@ struct CounterTreeWithMap {
 };
 
 struct CounterMultiMap {
-    void operator()(const PhPointD<3>& key, const payload_t& value) {
+    void operator()(const PhPointD<3>&, const payload_t& value) {
         n_ += CheckPosition(value, center_, radius_);
     }
     const TestPoint& center_;

--- a/phtree/benchmark/update_mm_box_d_benchmark.cc
+++ b/phtree/benchmark/update_mm_box_d_benchmark.cc
@@ -87,7 +87,7 @@ class IndexBenchmark {
 template <dimension_t DIM, Scenario SCENARIO>
 IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(
     benchmark::State& state, size_t updates_per_round, std::vector<double> move_distance)
-: data_type_{static_cast<const TestGenerator>(state.range(1))}
+: data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
 , updates_per_round_(updates_per_round)
 , move_distance_(std::move(move_distance))

--- a/phtree/benchmark/update_mm_box_d_benchmark.cc
+++ b/phtree/benchmark/update_mm_box_d_benchmark.cc
@@ -143,7 +143,7 @@ typename std::enable_if<SCENARIO == Scenario::TREE_WITH_MAP, size_t>::type Updat
         assert(iter_old_bucket != tree.end());
         bool success = iter_old_bucket->erase(update.id_);
         if (iter_old_bucket->empty()) {
-            success &= tree.erase(iter_old_bucket);
+            success &= tree.erase(iter_old_bucket) != 0;
         }
         n += success;
     }

--- a/phtree/benchmark/update_mm_box_d_benchmark.cc
+++ b/phtree/benchmark/update_mm_box_d_benchmark.cc
@@ -203,6 +203,7 @@ void IndexBenchmark<DIM, SCENARIO>::UpdateWorld(benchmark::State& state) {
     }
 
     if constexpr (SCENARIO == MULTI_MAP) {
+        (void)initial_tree_size;
         if (tree_.size() != num_entities_) {
             logging::error("Invalid index size after update: {}/{}", tree_.size(), num_entities_);
         }

--- a/phtree/benchmark/update_mm_d_benchmark.cc
+++ b/phtree/benchmark/update_mm_d_benchmark.cc
@@ -89,7 +89,7 @@ class IndexBenchmark {
 template <dimension_t DIM, Scenario SCENARIO>
 IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(
     benchmark::State& state, size_t updates_per_round, std::vector<double> move_distance)
-: data_type_{static_cast<const TestGenerator>(state.range(1))}
+: data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
 , updates_per_round_(updates_per_round)
 , move_distance_(std::move(move_distance))

--- a/phtree/benchmark/update_mm_d_benchmark.cc
+++ b/phtree/benchmark/update_mm_d_benchmark.cc
@@ -145,7 +145,7 @@ typename std::enable_if<SCENARIO == Scenario::TREE_WITH_MAP, size_t>::type Updat
         assert(iter_old_bucket != tree.end());
         bool success = iter_old_bucket->erase(update.id_);
         if (iter_old_bucket->empty()) {
-            success &= tree.erase(iter_old_bucket);
+            success &= tree.erase(iter_old_bucket) != 0;
         }
         n += success;
     }

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -151,13 +151,10 @@ class FilterAABB {
     const CONVERTER converter_;
 };
 
-
 /*
  * The sphere filter can be used to query a point tree for a sphere.
  */
-template <
-    typename CONVERTER = ConverterIEEE<3>,
-    typename DISTANCE = DistanceEuclidean<3>>
+template <typename CONVERTER = ConverterIEEE<3>, typename DISTANCE = DistanceEuclidean<3>>
 class FilterSphere {
     using KeyExternal = typename CONVERTER::KeyExternal;
     using KeyInternal = typename CONVERTER::KeyInternal;
@@ -177,7 +174,7 @@ class FilterSphere {
     , distance_function_{distance_function} {};
 
     template <typename T>
-    [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T& value) const {
+    [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T&) const {
         KeyExternal point = converter_.post(key);
         return distance_function_(center_external_, point) <= radius_;
     }

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -64,7 +64,7 @@ struct FilterNoOp {
      * @returns This default implementation always returns `true`.
      */
     template <typename KEY, typename T>
-    constexpr bool IsEntryValid(const KEY& key, const T& value) const {
+    constexpr bool IsEntryValid(const KEY& /*key*/, const T& /*value*/) const {
         return true;
     }
 
@@ -77,7 +77,7 @@ struct FilterNoOp {
      * @returns This default implementation always returns `true`.
      */
     template <typename KEY>
-    constexpr bool IsNodeValid(const KEY& prefix, int bits_to_ignore) const {
+    constexpr bool IsNodeValid(const KEY& /*prefix*/, int /*bits_to_ignore*/) const {
         return true;
     }
 };
@@ -116,7 +116,7 @@ class FilterAABB {
     }
 
     template <typename T>
-    [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T& value) const {
+    [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T& /*value*/) const {
         auto point = converter_.post(key);
         for (dimension_t i = 0; i < DIM; ++i) {
             if (point[i] < min_external_[i] || point[i] > max_external_[i]) {

--- a/phtree/common/flat_array_map.h
+++ b/phtree/common/flat_array_map.h
@@ -95,14 +95,14 @@ class array_map {
         return PhFlatMapIterator<T, SIZE>{SIZE, *this};
     }
 
-    template <typename... _Args>
-    auto emplace(_Args&&... __args) {
-        return try_emplace_base(std::forward<_Args>(__args)...);
+    template <typename... Args>
+    auto emplace(Args&&... args) {
+        return try_emplace_base(std::forward<Args>(args)...);
     }
 
-    template <typename... _Args>
-    auto try_emplace(size_t index, _Args&&... __args) {
-        return try_emplace_base(index, std::forward<_Args>(__args)...);
+    template <typename... Args>
+    auto try_emplace(size_t index, Args&&... args) {
+        return try_emplace_base(index, std::forward<Args>(args)...);
     }
 
     bool erase(size_t index) {
@@ -123,13 +123,13 @@ class array_map {
     }
 
   private:
-    template <typename... _Args>
-    std::pair<PhFlatMapPair<T>*, bool> try_emplace_base(size_t index, _Args&&... __args) {
+    template <typename... Args>
+    std::pair<PhFlatMapPair<T>*, bool> try_emplace_base(size_t index, Args&&... args) {
         if (!occupied(index)) {
             new (reinterpret_cast<void*>(&data_[index])) PhFlatMapPair<T>(
                 std::piecewise_construct,
                 std::forward_as_tuple(index),
-                std::forward_as_tuple(std::forward<_Args>(__args)...));
+                std::forward_as_tuple(std::forward<Args>(args)...));
             occupied(index, true);
             return {&data(index), true};
         }

--- a/phtree/common/flat_array_map.h
+++ b/phtree/common/flat_array_map.h
@@ -192,7 +192,7 @@ class PhFlatMapIterator {
         return const_cast<PhFlatMapPair<T>&>(map_->data(first));
     }
 
-    auto* operator-> () const {
+    auto* operator->() const {
         assert(first < SIZE && map_->occupied(first));
         return const_cast<PhFlatMapPair<T>*>(&map_->data(first));
     }

--- a/phtree/common/flat_array_map.h
+++ b/phtree/common/flat_array_map.h
@@ -183,7 +183,6 @@ class PhFlatMapIterator {
 
     explicit PhFlatMapIterator(size_t index, const array_map<T, SIZE>& map)
     : first{index}, map_{&map} {
-        assert(index >= 0);
         assert(index <= SIZE);
     }
 

--- a/phtree/common/flat_array_map.h
+++ b/phtree/common/flat_array_map.h
@@ -157,6 +157,7 @@ class array_map {
     }
 
     void occupied(size_t index, bool flag) {
+        (void)flag;
         assert(index < SIZE);
         assert(occupied(index) != flag);
         // flip the bit

--- a/phtree/common/flat_sparse_map.h
+++ b/phtree/common/flat_sparse_map.h
@@ -98,14 +98,14 @@ class sparse_map {
         return data_.end();
     }
 
-    template <typename... _Args>
-    auto emplace(_Args&&... __args) {
-        return try_emplace_base(std::forward<_Args>(__args)...);
+    template <typename... Args>
+    auto emplace(Args&&... args) {
+        return try_emplace_base(std::forward<Args>(args)...);
     }
 
-    template <typename... _Args>
-    auto try_emplace(size_t key, _Args&&... __args) {
-        return try_emplace_base(key, std::forward<_Args>(__args)...);
+    template <typename... Args>
+    auto try_emplace(size_t key, Args&&... args) {
+        return try_emplace_base(key, std::forward<Args>(args)...);
     }
 
     void erase(size_t key) {
@@ -124,18 +124,18 @@ class sparse_map {
     }
 
   private:
-    template <typename... _Args>
-    auto emplace_base(size_t key, _Args&&... __args) {
+    template <typename... Args>
+    auto emplace_base(size_t key, Args&&... args) {
         auto it = lower_bound(key);
         if (it != end() && it->first == key) {
             return std::make_pair(it, false);
         } else {
-            return std::make_pair(data_.emplace(it, key, std::forward<T>(__args)...), true);
+            return std::make_pair(data_.emplace(it, key, std::forward<Args>(args)...), true);
         }
     }
 
-    template <typename... _Args>
-    auto try_emplace_base(size_t key, _Args&&... __args) {
+    template <typename... Args>
+    auto try_emplace_base(size_t key, Args&&... args) {
         auto it = lower_bound(key);
         if (it != end() && it->first == key) {
             return std::make_pair(it, false);
@@ -144,7 +144,7 @@ class sparse_map {
                 it,
                 std::piecewise_construct,
                 std::forward_as_tuple(key),
-                std::forward_as_tuple(std::forward<_Args>(__args)...));
+                std::forward_as_tuple(std::forward<Args>(args)...));
             return std::make_pair(x, true);
         }
     }

--- a/phtree/phtree.h
+++ b/phtree/phtree.h
@@ -49,7 +49,7 @@ class PhTree {
      *
      *  @param key The key for the new entry.
      *
-     *  @param __args  Arguments used to generate a new value.
+     *  @param args  Arguments used to generate a new value.
      *
      *  @return  A pair, whose first element points  to the possibly inserted pair,
      *           and whose second element is a bool that is true if the pair was actually inserted.
@@ -58,9 +58,9 @@ class PhTree {
      * effectively a map, so if an entry with the same key was already in the tree, returns that
      * entry instead of inserting a new one.
      */
-    template <typename... _Args>
-    std::pair<T&, bool> emplace(const Key& key, _Args&&... __args) {
-        return tree_.emplace(converter_.pre(key), std::forward<_Args>(__args)...);
+    template <typename... Args>
+    std::pair<T&, bool> emplace(const Key& key, Args&&... args) {
+        return tree_.emplace(converter_.pre(key), std::forward<Args>(args)...);
     }
 
     /*
@@ -78,9 +78,9 @@ class PhTree {
      * erase(iter);
      * emplace_hint(iter, key2, value);  // the iterator can still be used as hint here
      */
-    template <typename ITERATOR, typename... _Args>
-    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const Key& key, _Args&&... __args) {
-        return tree_.emplace_hint(iterator, converter_.pre(key), std::forward<_Args>(__args)...);
+    template <typename ITERATOR, typename... Args>
+    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const Key& key, Args&&... args) {
+        return tree_.emplace_hint(iterator, converter_.pre(key), std::forward<Args>(args)...);
     }
 
     /*

--- a/phtree/phtree_box_d_test.cc
+++ b/phtree/phtree_box_d_test.cc
@@ -86,7 +86,7 @@ void generateCube(std::vector<PhBoxD<DIM>>& points, size_t N, double boxLen = 10
             continue;
         }
 
-        refTree.emplace(box, i);
+        refTree.emplace(box, i + 1);
         points.push_back(box);
     }
     ASSERT_EQ(refTree.size(), N);
@@ -356,7 +356,7 @@ void populate(
     PhTreeBoxD<DIM, size_t>& tree, std::vector<PhBoxD<DIM>>& points, size_t N, double boxLen = 10) {
     generateCube(points, N, boxLen);
     for (size_t i = 0; i < N; i++) {
-        ASSERT_TRUE(tree.insert(points[i], i).second);
+        ASSERT_TRUE(tree.insert(points[i], i + 1).second);
     }
     ASSERT_EQ(N, tree.size());
 }
@@ -366,7 +366,7 @@ void populate(
     TestTree<DIM, Id>& tree, std::vector<PhBoxD<DIM>>& points, size_t N, double boxLen = 10) {
     generateCube(points, N, boxLen);
     for (size_t i = 0; i < N; i++) {
-        ASSERT_TRUE(tree.emplace(points[i], i).second);
+        ASSERT_TRUE(tree.emplace(points[i], i + 1).second);
     }
     ASSERT_EQ(N, tree.size());
 }
@@ -409,7 +409,7 @@ TEST(PhTreeBoxDTest, TestFind) {
         // test commutativity
         ASSERT_NE(tree.find(p), tree.end());
         ASSERT_NE(tree.end(), tree.find(p));
-        ASSERT_EQ(tree.find(p)->_i, i);
+        ASSERT_EQ(tree.find(p)->_i, i + 1);
         i++;
     }
 
@@ -522,7 +522,7 @@ TEST(PhTreeBoxDTest, TestExtent) {
     int num_e = 0;
     auto qE = tree.begin();
     while (qE != tree.end()) {
-        ASSERT_TRUE(qE->_i >= 0);
+        ASSERT_TRUE(qE->_i >= 1);
         qE++;
         num_e++;
     }
@@ -538,14 +538,14 @@ TEST(PhTreeBoxDTest, TestRangeBasedForLoop) {
 
     int num_e1 = 0;
     for (auto& x : tree) {
-        ASSERT_TRUE(x._i >= 0);
+        ASSERT_TRUE(x._i >= 1);
         num_e1++;
     }
     ASSERT_EQ(N, num_e1);
 
     size_t num_e2 = 0;
     for (auto& x : tree) {
-        ASSERT_TRUE(x._i >= 0);
+        ASSERT_TRUE(x._i >= 1);
         num_e2++;
     }
     ASSERT_EQ(N, num_e2);
@@ -566,7 +566,7 @@ void referenceQuery(
             match &= pMax[d] >= min[d] && pMin[d] <= max[d];
         }
         if (match) {
-            result.insert(i);
+            result.insert(i + 1);
         }
     }
 }
@@ -612,7 +612,7 @@ TEST(PhTreeBoxDTest, TestWindowQuery1) {
         // With intersection queries we may get multiple results.
         size_t found = 0;
         for (auto q = tree.begin_query(p); q != tree.end(); ++q) {
-            found += (i == (*q)._i);
+            found += (i + 1 == (*q)._i);
         }
         ASSERT_EQ(1, found);
         n++;

--- a/phtree/phtree_box_d_test.cc
+++ b/phtree/phtree_box_d_test.cc
@@ -716,7 +716,7 @@ TEST(PhTreeBoxDTest, TestWindowForEachManyMovingPoint) {
         referenceQuery(points, min_max, min_max, referenceResult);
 
         struct Counter {
-            void operator()(PhBoxD<dim> key, Id& t) {
+            void operator()(PhBoxD<dim>, Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_box_f_test.cc
+++ b/phtree/phtree_box_f_test.cc
@@ -720,7 +720,7 @@ TEST(PhTreeBoxFTest, TestWindowForEachManyMovingPoint) {
         referenceQuery(points, min_max, min_max, referenceResult);
 
         struct Counter {
-            void operator()(TestPoint<dim> key, Id& t) {
+            void operator()(TestPoint<dim>, Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_box_f_test.cc
+++ b/phtree/phtree_box_f_test.cc
@@ -93,7 +93,7 @@ void generateCube(std::vector<TestPoint<DIM>>& points, size_t N, float boxLen = 
             continue;
         }
 
-        refTree.emplace(box, i);
+        refTree.emplace(box, i + 1);
         points.push_back(box);
     }
     ASSERT_EQ(refTree.size(), N);
@@ -360,7 +360,7 @@ void populate(
     double boxLen = 10) {
     generateCube(points, N, boxLen);
     for (size_t i = 0; i < N; i++) {
-        ASSERT_TRUE(tree.insert(points[i], i).second);
+        ASSERT_TRUE(tree.insert(points[i], i + 1).second);
     }
     ASSERT_EQ(N, tree.size());
 }
@@ -370,7 +370,7 @@ void populate(
     TestTree<DIM, Id>& tree, std::vector<TestPoint<DIM>>& points, size_t N, double boxLen = 10) {
     generateCube(points, N, boxLen);
     for (size_t i = 0; i < N; i++) {
-        ASSERT_TRUE(tree.emplace(points[i], i).second);
+        ASSERT_TRUE(tree.emplace(points[i], i + 1).second);
     }
     ASSERT_EQ(N, tree.size());
 }
@@ -413,7 +413,7 @@ TEST(PhTreeBoxFTest, TestFind) {
         // test commutativity
         ASSERT_NE(tree.find(p), tree.end());
         ASSERT_NE(tree.end(), tree.find(p));
-        ASSERT_EQ(tree.find(p)->_i, i);
+        ASSERT_EQ(tree.find(p)->_i, i + 1);
         i++;
     }
 
@@ -526,7 +526,7 @@ TEST(PhTreeBoxFTest, TestExtent) {
     int num_e = 0;
     auto qE = tree.begin();
     while (qE != tree.end()) {
-        ASSERT_TRUE(qE->_i >= 0);
+        ASSERT_TRUE(qE->_i >= 1);
         qE++;
         num_e++;
     }
@@ -542,14 +542,14 @@ TEST(PhTreeBoxFTest, TestRangeBasedForLoop) {
 
     int num_e1 = 0;
     for (auto& x : tree) {
-        ASSERT_TRUE(x._i >= 0);
+        ASSERT_TRUE(x._i >= 1);
         num_e1++;
     }
     ASSERT_EQ(N, num_e1);
 
     size_t num_e2 = 0;
     for (auto& x : tree) {
-        ASSERT_TRUE(x._i >= 0);
+        ASSERT_TRUE(x._i >= 1);
         num_e2++;
     }
     ASSERT_EQ(N, num_e2);
@@ -570,7 +570,7 @@ void referenceQuery(
             match &= pMax[d] >= min[d] && pMin[d] <= max[d];
         }
         if (match) {
-            result.insert(i);
+            result.insert(i + 1);
         }
     }
 }
@@ -616,7 +616,7 @@ TEST(PhTreeBoxFTest, TestWindowQuery1) {
         // With intersection queries we may get multiple results.
         size_t found = 0;
         for (auto q = tree.begin_query(p); q != tree.end(); ++q) {
-            found += (i == (*q)._i);
+            found += (i + 1 == (*q)._i);
         }
         ASSERT_EQ(1, found);
         n++;

--- a/phtree/phtree_d_test.cc
+++ b/phtree/phtree_d_test.cc
@@ -543,10 +543,10 @@ TEST(PhTreeDTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };
@@ -729,7 +729,7 @@ TEST(PhTreeDTest, TestWindowForEachQueryManyMoving) {
         referenceQuery(points, min, max, referenceResult);
 
         struct Counter {
-            void operator()(TestPoint<dim> key, Id& t) {
+            void operator()(TestPoint<dim>, Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_d_test_custom_key.cc
+++ b/phtree/phtree_d_test_custom_key.cc
@@ -68,9 +68,10 @@ class MyConverterMultiply : public ConverterBase<3, 3, double, scalar_64_t, MyPo
     : multiplier_{multiplier}, divider_{1. / multiplier} {}
 
     [[nodiscard]] PointInternal pre(const MyPoint& point) const {
-        return {static_cast<long>(point.x_ * multiplier_),
-                static_cast<long>(point.y_ * multiplier_),
-                static_cast<long>(point.z_ * multiplier_)};
+        return {
+            static_cast<long>(point.x_ * multiplier_),
+            static_cast<long>(point.y_ * multiplier_),
+            static_cast<long>(point.z_ * multiplier_)};
     }
 
     [[nodiscard]] MyPoint post(const PointInternal& in) const {

--- a/phtree/phtree_f_test.cc
+++ b/phtree/phtree_f_test.cc
@@ -439,9 +439,10 @@ TEST(PhTreeFTest, TestUpdateWithEmplace) {
 
     for (auto& p : points) {
         auto pOld = p;
-        TestPoint<dim> pNew{static_cast<float>(pOld[0] + delta),
-                            static_cast<float>(pOld[1] + delta),
-                            static_cast<float>(pOld[2] + delta)};
+        TestPoint<dim> pNew{
+            static_cast<float>(pOld[0] + delta),
+            static_cast<float>(pOld[1] + delta),
+            static_cast<float>(pOld[2] + delta)};
         int n = tree.erase(pOld);
         ASSERT_EQ(1, n);
         tree.emplace(pNew, 42);
@@ -516,11 +517,10 @@ TEST(PhTreeFTest, TestExtent) {
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
     [[nodiscard]] constexpr bool IsEntryValid(
-        const PhPoint<DIM, scalar_32_t>& key, const T& value) const {
+        const PhPoint<DIM, scalar_32_t>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(
-        const PhPoint<DIM, scalar_32_t>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM, scalar_32_t>&, int) const {
         return true;
     }
 };
@@ -665,9 +665,10 @@ TEST(PhTreeFTest, TestWindowQueryManyMoving) {
     for (int i = -120; i < 120; i++) {
         TestPoint<dim> min{
             static_cast<float>(i * 10.), static_cast<float>(i * 9.), static_cast<float>(i * 11.)};
-        TestPoint<dim> max{static_cast<float>(i * 10 + query_length),
-                           static_cast<float>(i * 9 + query_length),
-                           static_cast<float>(i * 11 + query_length)};
+        TestPoint<dim> max{
+            static_cast<float>(i * 10 + query_length),
+            static_cast<float>(i * 9 + query_length),
+            static_cast<float>(i * 11 + query_length)};
         std::set<size_t> referenceResult;
         referenceQuery(points, min, max, referenceResult);
 
@@ -702,14 +703,15 @@ TEST(PhTreeFTest, TestWindowForEachQueryManyMoving) {
     for (int i = -120; i < 120; i++) {
         TestPoint<dim> min{
             static_cast<float>(i * 10.), static_cast<float>(i * 9.), static_cast<float>(i * 11.)};
-        TestPoint<dim> max{static_cast<float>(i * 10 + query_length),
-                           static_cast<float>(i * 9 + query_length),
-                           static_cast<float>(i * 11 + query_length)};
+        TestPoint<dim> max{
+            static_cast<float>(i * 10 + query_length),
+            static_cast<float>(i * 9 + query_length),
+            static_cast<float>(i * 11 + query_length)};
         std::set<size_t> referenceResult;
         referenceQuery(points, min, max, referenceResult);
 
         struct Counter {
-            void operator()(TestPoint<dim> key, Id& t) {
+            void operator()(TestPoint<dim>, Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_multimap.h
+++ b/phtree/phtree_multimap.h
@@ -243,7 +243,7 @@ class PhTreeMultiMap {
      *
      *  @param key The key for the new entry.
      *
-     *  @param __args  Arguments used to generate a new value.
+     *  @param args  Arguments used to generate a new value.
      *
      *  @return  A pair, whose first element points to the possibly inserted pair,
      *           and whose second element is a bool that is true if the pair was actually inserted.
@@ -252,10 +252,10 @@ class PhTreeMultiMap {
      * effectively a multi-set, so if an entry with the same key/value was already in the tree, it
      * returns that entry instead of inserting a new one.
      */
-    template <typename... _Args>
-    std::pair<T&, bool> emplace(const Key& key, _Args&&... __args) {
+    template <typename... Args>
+    std::pair<T&, bool> emplace(const Key& key, Args&&... args) {
         auto& outer_iter = tree_.emplace(converter_.pre(key)).first;
-        auto bucket_iter = outer_iter.emplace(std::forward<_Args>(__args)...);
+        auto bucket_iter = outer_iter.emplace(std::forward<Args>(args)...);
         size_ += bucket_iter.second ? 1 : 0;
         return {const_cast<T&>(*bucket_iter.first), bucket_iter.second};
     }
@@ -275,20 +275,20 @@ class PhTreeMultiMap {
      * erase(iter);
      * emplace_hint(iter, key2, value);  // the iterator can still be used as hint here
      */
-    template <typename ITERATOR, typename... _Args>
-    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const Key& key, _Args&&... __args) {
+    template <typename ITERATOR, typename... Args>
+    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const Key& key, Args&&... args) {
         auto result_ph = tree_.emplace_hint(iterator.GetIteratorOfPhTree(), converter_.pre(key));
         auto& bucket = result_ph.first;
         if (result_ph.second) {
             // new bucket
-            auto result = bucket.emplace(std::forward<_Args>(__args)...);
+            auto result = bucket.emplace(std::forward<Args>(args)...);
             size_ += result.second;
             return {const_cast<T&>(*result.first), result.second};
         } else {
             // existing bucket -> we can use emplace_hint with iterator
             size_t old_size = bucket.size();
             auto result =
-                bucket.emplace_hint(iterator.GetIteratorOfBucket(), std::forward<_Args>(__args)...);
+                bucket.emplace_hint(iterator.GetIteratorOfBucket(), std::forward<Args>(args)...);
             bool success = old_size < bucket.size();
             size_ += success;
             return {const_cast<T&>(*result), success};

--- a/phtree/phtree_multimap.h
+++ b/phtree/phtree_multimap.h
@@ -328,7 +328,7 @@ class PhTreeMultiMap {
     template <typename QUERY_TYPE = DEFAULT_QUERY_TYPE>
     size_t estimate_count(QueryBox query_box, QUERY_TYPE query_type = QUERY_TYPE()) const {
         size_t n = 0;
-        auto counter_lambda = [&](const Key& key, const BUCKET& bucket) { n += bucket.size(); };
+        auto counter_lambda = [&](const Key&, const BUCKET& bucket) { n += bucket.size(); };
         tree_.for_each(query_type(converter_.pre_query(query_box)), counter_lambda);
         return n;
     }
@@ -661,8 +661,7 @@ class PhTreeMultiMap {
         // The original filter is then used when we iterate over the entries of a bucket. At this
         // point, we do not need to check IsNodeValid anymore for each entry (see `IteratorNormal`).
         struct FilterWrapper {
-            [[nodiscard]] constexpr bool IsEntryValid(
-                const KeyInternal& key, const BUCKET& value) const {
+            [[nodiscard]] constexpr bool IsEntryValid(const KeyInternal&, const BUCKET&) const {
                 // This filter is checked in the Iterator.
                 return true;
             }

--- a/phtree/phtree_multimap_box_d_test.cc
+++ b/phtree/phtree_multimap_box_d_test.cc
@@ -583,11 +583,10 @@ TEST(PhTreeMMBoxDTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<2 * DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<2 * DIM>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(
-        const PhPoint<2 * DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<2 * DIM>&, int) const {
         return true;
     }
 };
@@ -872,7 +871,7 @@ TEST(PhTreeMMBoxDTest, TestWindowForEachManyMovingPoint) {
         referenceQuery(points, min_max, min_max, referenceResult);
 
         struct Counter {
-            void operator()(const TestPoint<dim>& key, const Id& t) {
+            void operator()(const TestPoint<dim>&, const Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_multimap_d_test.cc
+++ b/phtree/phtree_multimap_d_test.cc
@@ -585,10 +585,10 @@ TEST(PhTreeMMDTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };
@@ -818,7 +818,7 @@ TEST(PhTreeMMDTest, TestWindowForEachQueryManyMoving) {
         referenceQuery(points, min, max, referenceResult);
 
         struct Counter {
-            void operator()(const TestPoint<dim>& key, const Id& t) {
+            void operator()(const TestPoint<dim>&, const Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_test.cc
+++ b/phtree/phtree_test.cc
@@ -601,10 +601,10 @@ TEST(PhTreeTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };
@@ -787,7 +787,7 @@ TEST(PhTreeTest, TestWindowForEachManyMoving) {
         referenceQuery(points, min, max, referenceResult);
 
         struct Counter {
-            void operator()(TestPoint<dim> key, Id& t) {
+            void operator()(TestPoint<dim>, Id& t) {
                 ++n_;
                 ASSERT_EQ(referenceResult.count(t._i), 1);
             }

--- a/phtree/phtree_test.cc
+++ b/phtree/phtree_test.cc
@@ -62,7 +62,7 @@ struct Id {
         ++default_construct_count_;
     }
 
-    explicit Id(const int i) : _i{i} {
+    explicit Id(const size_t i) : _i{(int)i} {
         ++construct_count_;
     };
 
@@ -76,12 +76,12 @@ struct Id {
         _i = other._i;
     }
 
-    bool operator==(const Id& rhs) {
+    bool operator==(const Id& rhs) const {
         ++copy_assign_count_;
         return _i == rhs._i;
     }
 
-    bool operator==(Id&& rhs) {
+    bool operator==(Id&& rhs) const {
         ++move_assign_count_;
         return _i == rhs._i;
     }
@@ -386,7 +386,7 @@ TEST(PhTreeTest, TestSquareBrackets) {
         ASSERT_EQ(0, tree[p]._i);
         ASSERT_EQ(tree.count(p), 1);
         if (i % 2 == 0) {
-            tree[p]._i = i;
+            tree[p]._i = (int)i;
         } else {
             tree[p] = id;
         }
@@ -430,7 +430,7 @@ template <dimension_t DIM>
 void populate(TestTree<DIM, Id>& tree, std::vector<TestPoint<DIM>>& points, size_t N) {
     generateCube(points, N);
     for (size_t i = 0; i < N; i++) {
-        ASSERT_TRUE(tree.emplace(points[i], (int)i).second);
+        ASSERT_TRUE(tree.emplace(points[i], i).second);
     }
     ASSERT_EQ(N, tree.size());
 }

--- a/phtree/phtree_test_const_values.cc
+++ b/phtree/phtree_test_const_values.cc
@@ -445,10 +445,10 @@ TEST(PhTreeTestConst, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
         return value._i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };

--- a/phtree/phtree_test_ptr_values.cc
+++ b/phtree/phtree_test_ptr_values.cc
@@ -511,10 +511,10 @@ TEST(PhTreeTestPtr, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct PhFilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>& key, const T& value) const {
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
         return value->_i % 2 == 0;
     }
-    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
     }
 };

--- a/phtree/phtree_test_ptr_values.cc
+++ b/phtree/phtree_test_ptr_values.cc
@@ -42,9 +42,9 @@ class IntRng {
 struct Id {
     Id() = default;
 
-    explicit Id(const int i) : _i(i){};
+    explicit Id(const size_t i) : _i((int)i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(Id& rhs) const {
         return _i == rhs._i;
     }
 
@@ -467,7 +467,7 @@ TEST(PhTreeTestPtr, TestUpdateWithEmplace) {
     for (auto& p : points) {
         auto pOld = p;
         PhPoint<dim> pNew{pOld[0] + delta, pOld[1] + delta, pOld[2] + delta};
-        int n = tree.erase(pOld);
+        size_t n = tree.erase(pOld);
         ASSERT_EQ(1, n);
         tree.emplace(pNew, new Id(42));
         ASSERT_EQ(1, tree.count(pNew));

--- a/phtree/v16/entry.h
+++ b/phtree/v16/entry.h
@@ -66,9 +66,9 @@ class Entry {
     /*
      * Construct entry with new T or moved T.
      */
-    template <typename... _Args>
-    explicit Entry(const KeyT& k, _Args&&... __args)
-    : kd_key_{k}, value_{std::in_place_type<ValueT>, std::forward<_Args>(__args)...} {}
+    template <typename... Args>
+    explicit Entry(const KeyT& k, Args&&... args)
+    : kd_key_{k}, value_{std::in_place_type<ValueT>, std::forward<Args>(args)...} {}
 
     [[nodiscard]] const KeyT& GetKey() const {
         return kd_key_;

--- a/phtree/v16/node.h
+++ b/phtree/v16/node.h
@@ -145,35 +145,35 @@ class Node {
      * The scenarios in detail:
      *
      * If there is no entry at the position of 'hc_pos', a new entry is inserted. The new entry is
-     * constructed from a constructor of T that accepts the arguments __args. Also, 'is_inserted' is
+     * constructed from a constructor of T that accepts the arguments `args`. Also, 'is_inserted' is
      * set top 'true'.
      *
-     * If there is a is a entry with a value T at 'hc_pos', that value is returned. The value is
+     * If there is an entry with a value T at 'hc_pos', that value is returned. The value is
      * _not_ overwritten.
      *
-     * If there is a child node at the position of 'hc_pos', the child node's prefix is is analysed.
+     * If there is a child node at the position of 'hc_pos', the child node's prefix is analysed.
      * If the prefix indicates that the new value would end up inside the child node or any of its
      * children, then the child node is returned for further traversal.
      * If the child nodes' prefix is different, then a new node is created. The new node contains
-     * the child node and a new key/value entry constructed with __args. The new node is inserted in
+     * the child node and a new key/value entry constructed with `args`. The new node is inserted in
      * the current node at the position of the former child node. The new value is returned and
      * 'is_inserted' is set to 'true'.
      *
      * @param is_inserted The function will set this to true if a new value was inserted
      * @param key The key for which a new value should be inserted.
-     * @param __args Constructor arguments for creating a value T that can be inserted for the key.
+     * @param args Constructor arguments for creating a value T that can be inserted for the key.
      */
-    template <typename... _Args>
-    EntryT* Emplace(bool& is_inserted, const KeyT& key, _Args&&... __args) {
+    template <typename... Args>
+    EntryT* Emplace(bool& is_inserted, const KeyT& key, Args&&... args) {
         hc_pos_t hc_pos = CalcPosInArray(key, GetPostfixLen());
-        auto emplace_result = entries_.try_emplace(hc_pos, key, std::forward<_Args>(__args)...);
+        auto emplace_result = entries_.try_emplace(hc_pos, key, std::forward<Args>(args)...);
         auto& entry = emplace_result.first->second;
         // Return if emplace succeed, i.e. there was no entry.
         if (emplace_result.second) {
             is_inserted = true;
             return &entry;
         }
-        return HandleCollision(entry, is_inserted, key, std::forward<_Args>(__args)...);
+        return HandleCollision(entry, is_inserted, key, std::forward<Args>(args)...);
     }
 
     /*
@@ -280,9 +280,9 @@ class Node {
     }
 
   private:
-    template <typename... _Args>
-    auto& WriteValue(hc_pos_t hc_pos, const KeyT& new_key, _Args&&... __args) {
-        return entries_.try_emplace(hc_pos, new_key, std::forward<_Args>(__args)...).first->second;
+    template <typename... Args>
+    auto& WriteValue(hc_pos_t hc_pos, const KeyT& new_key, Args&&... args) {
+        return entries_.try_emplace(hc_pos, new_key, std::forward<Args>(args)...).first->second;
     }
 
     void WriteEntry(hc_pos_t hc_pos, EntryT&& entry) {
@@ -301,16 +301,16 @@ class Node {
      * @param is_inserted Output: This will be set to 'true' by this function if a new entry was
      * inserted by this function.
      * @param new_key The key of the entry to be inserted
-     * @param __args The constructor arguments for a new value T of a the new entry to be inserted
+     * @param args The constructor arguments for a new value T of a the new entry to be inserted
      * @return A Entry that may contain a child node, a newly created entry or an existing entry.
      * A child node indicates that no entry was inserted, but the caller should try inserting into
      * the child node. A newly created entry (indicated by is_inserted=true) indicates successful
      * insertion. An existing entry (indicated by is_inserted=false) indicates that there is already
      * an entry with the exact same key as new_key, so insertion has failed.
      */
-    template <typename... _Args>
+    template <typename... Args>
     auto* HandleCollision(
-        EntryT& existing_entry, bool& is_inserted, const KeyT& new_key, _Args&&... __args) {
+        EntryT& existing_entry, bool& is_inserted, const KeyT& new_key, Args&&... args) {
         assert(!is_inserted);
         // We have two entries in the same location (local pos).
         // Now we need to compare the keys.
@@ -323,10 +323,7 @@ class Node {
                 if (max_conflicting_bits > sub_node.GetPostfixLen() + 1) {
                     is_inserted = true;
                     return InsertSplit(
-                        existing_entry,
-                        new_key,
-                        max_conflicting_bits,
-                        std::forward<_Args>(__args)...);
+                        existing_entry, new_key, max_conflicting_bits, std::forward<Args>(args)...);
                 }
             }
             // No infix conflict, just traverse subnode
@@ -336,19 +333,19 @@ class Node {
             if (max_conflicting_bits > 0) {
                 is_inserted = true;
                 return InsertSplit(
-                    existing_entry, new_key, max_conflicting_bits, std::forward<_Args>(__args)...);
+                    existing_entry, new_key, max_conflicting_bits, std::forward<Args>(args)...);
             }
             // perfect match -> return existing
         }
         return &existing_entry;
     }
 
-    template <typename... _Args>
+    template <typename... Args>
     auto* InsertSplit(
         EntryT& current_entry,
         const KeyT& new_key,
         bit_width_t max_conflicting_bits,
-        _Args&&... __args) {
+        Args&&... args) {
         const auto current_key = current_entry.GetKey();
 
         // determine length of infix
@@ -360,8 +357,7 @@ class Node {
 
         // Move key/value into subnode
         new_sub_node->WriteEntry(pos_sub_2, std::move(current_entry));
-        auto& new_entry =
-            new_sub_node->WriteValue(pos_sub_1, new_key, std::forward<_Args>(__args)...);
+        auto& new_entry = new_sub_node->WriteValue(pos_sub_1, new_key, std::forward<Args>(args)...);
 
         // Insert new node into local node
         // We use new_key because current_key has been moved().

--- a/phtree/v16/phtree_v16.h
+++ b/phtree/v16/phtree_v16.h
@@ -80,7 +80,7 @@ class PhTreeV16 {
      *
      *  @param key The key for the new entry.
      *
-     *  @param __args  Arguments used to generate a new value.
+     *  @param args  Arguments used to generate a new value.
      *
      *  @return  A pair, whose first element points  to the possibly inserted pair,
      *           and whose second element is a bool that is true if the pair was actually inserted.
@@ -89,13 +89,13 @@ class PhTreeV16 {
      * effectively a map, so if an entry with the same key was already in the tree, returns that
      * entry instead of inserting a new one.
      */
-    template <typename... _Args>
-    std::pair<T&, bool> emplace(const KeyT& key, _Args&&... __args) {
+    template <typename... Args>
+    std::pair<T&, bool> emplace(const KeyT& key, Args&&... args) {
         auto* current_entry = &root_;
         bool is_inserted = false;
         while (current_entry->IsNode()) {
             current_entry =
-                current_entry->GetNode().Emplace(is_inserted, key, std::forward<_Args>(__args)...);
+                current_entry->GetNode().Emplace(is_inserted, key, std::forward<Args>(args)...);
         }
         num_entries_ += is_inserted;
         return {current_entry->GetValue(), is_inserted};
@@ -116,8 +116,8 @@ class PhTreeV16 {
      * erase(iter);
      * emplace_hint(iter, key2, value);  // the iterator can still be used as hint here
      */
-    template <typename ITERATOR, typename... _Args>
-    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const KeyT& key, _Args&&... __args) {
+    template <typename ITERATOR, typename... Args>
+    std::pair<T&, bool> emplace_hint(const ITERATOR& iterator, const KeyT& key, Args&&... args) {
         // This function can be used to insert a value close to a known value
         // or close to a recently removed value. The hint can only be used if the new key is
         // inside one of the nodes provided by the hint iterator.
@@ -130,14 +130,14 @@ class PhTreeV16 {
 
         if (!iterator.GetParentNodeEntry()) {
             // No hint available, use standard emplace()
-            return emplace(key, std::forward<_Args>(__args)...);
+            return emplace(key, std::forward<Args>(args)...);
         }
 
         auto* parent_entry = iterator.GetParentNodeEntry();
         if (NumberOfDivergingBits(key, parent_entry->GetKey()) >
             parent_entry->GetNode().GetPostfixLen() + 1) {
             // replace higher up in the tree
-            return emplace(key, std::forward<_Args>(__args)...);
+            return emplace(key, std::forward<Args>(args)...);
         }
 
         // replace in node
@@ -145,7 +145,7 @@ class PhTreeV16 {
         bool is_inserted = false;
         while (current_entry->IsNode()) {
             current_entry =
-                current_entry->GetNode().Emplace(is_inserted, key, std::forward<_Args>(__args)...);
+                current_entry->GetNode().Emplace(is_inserted, key, std::forward<Args>(args)...);
         }
         num_entries_ += is_inserted;
         return {current_entry->GetValue(), is_inserted};


### PR DESCRIPTION
This PR fixes  with unused arguments warnings from 
* unused function arguments.
* general gcc/clang warnings
* MSVC warning
* warnings for using reserved identifiers (everything starting with `_`)